### PR TITLE
RAGコーパスにファイルをアップロードするときにdisplayNameを別途指定できるようにする

### DIFF
--- a/cmd/ragtool/cli/file.go
+++ b/cmd/ragtool/cli/file.go
@@ -26,7 +26,13 @@ func HandleFileUpload(ctx context.Context, cli *CLI, client *lib.Client) error {
 
 	fileName := filepath.Base(cli.File.Upload.File)
 
-	createdFile, err := client.UploadFile(ctx, corpusID, file, fileName, func(o *lib.UploadFileOptions) {
+	// DisplayNameが指定されていればそれを使用し、なければファイル名を使用
+	displayName := fileName
+	if cli.File.Upload.DisplayName != "" {
+		displayName = cli.File.Upload.DisplayName
+	}
+
+	createdFile, err := client.UploadFile(ctx, corpusID, file, displayName, func(o *lib.UploadFileOptions) {
 		if cli.File.Upload.Description != "" {
 			o.Description = cli.File.Upload.Description
 		}

--- a/cmd/ragtool/cli/types.go
+++ b/cmd/ragtool/cli/types.go
@@ -32,6 +32,7 @@ type CLI struct {
 		Upload struct {
 			File        string `arg:"" help:"Path to the file to upload" type:"path"`
 			CorpusID    string `required:"" help:"ID of the RAG corpus"`
+			DisplayName string `help:"Display name for the file (defaults to file name if not specified)"`
 			Description string `help:"Description of the file"`
 			ChunkSize   int    `help:"Size of each chunk" default:"1000"`
 			Overlap     int    `help:"Overlap between chunks" default:"100"`

--- a/internal/infrastructure/google/vertexai/rag/lib/upload_file.go
+++ b/internal/infrastructure/google/vertexai/rag/lib/upload_file.go
@@ -45,7 +45,7 @@ type UploadFileResponse struct {
 // References:
 // - Example: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api-v1#upload-a-rag-file-example-api
 // - Parameters: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api-v1#parameters-list
-func (c *Client) UploadFile(ctx context.Context, corpusId int64, file io.Reader, fileName string, options ...UploadFileOption) (File, error) {
+func (c *Client) UploadFile(ctx context.Context, corpusId int64, file io.Reader, displayName string, options ...UploadFileOption) (File, error) {
 	uploadFileOptions := &UploadFileOptions{}
 	for _, option := range options {
 		option(uploadFileOptions)
@@ -53,7 +53,7 @@ func (c *Client) UploadFile(ctx context.Context, corpusId int64, file io.Reader,
 
 	metadata := &UploadFileMetadata{
 		RagFile: &UploadFileMetadataRagFile{
-			DisplayName: fileName,
+			DisplayName: displayName,
 		},
 	}
 
@@ -86,7 +86,7 @@ func (c *Client) UploadFile(ctx context.Context, corpusId int64, file io.Reader,
 		return File{}, err
 	}
 
-	filePart, err := writer.CreateFormFile("file", fileName)
+	filePart, err := writer.CreateFormFile("file", displayName)
 	if err != nil {
 		return File{}, err
 	}


### PR DESCRIPTION
## 解きたい課題

CLIツールから使う場合、ファイル名と異なるdisplayNameを指定したいケースがあった

## やったこと

表題通り