### PR TITLE
Slackでメンションされたときにエージェントとして振る舞うようにする

### DIFF
--- a/internal/application/conversation.go
+++ b/internal/application/conversation.go
@@ -1,0 +1,150 @@
+package application
+
+import (
+	"context"
+	"docgent/internal/application/port"
+	"docgent/internal/application/tooluse"
+	"docgent/internal/domain"
+	domaintooluse "docgent/internal/domain/tooluse"
+	"fmt"
+	"strings"
+)
+
+// ConversationUsecase は、AIエージェントとしてユーザーとの会話を実行するユースケースです。
+type ConversationUsecase struct {
+	chatModel           domain.ChatModel
+	conversationService port.ConversationService
+	fileQueryService    port.FileQueryService
+	sourceRepositories  []port.SourceRepository
+	ragCorpus           port.RAGCorpus
+	remainingStepCount  int
+}
+
+// NewConversationUsecaseOption はConversationUsecaseの初期化オプションです。
+type NewConversationUsecaseOption func(*ConversationUsecase)
+
+// WithConversationRAGCorpus はRAGコーパスを設定するオプションです。
+func WithConversationRAGCorpus(ragCorpus port.RAGCorpus) NewConversationUsecaseOption {
+	return func(u *ConversationUsecase) {
+		u.ragCorpus = ragCorpus
+	}
+}
+
+// NewConversationUsecase はConversationUsecaseを初期化します。
+func NewConversationUsecase(
+	chatModel domain.ChatModel,
+	conversationService port.ConversationService,
+	fileQueryService port.FileQueryService,
+	sourceRepositories []port.SourceRepository,
+	options ...NewConversationUsecaseOption,
+) *ConversationUsecase {
+	u := &ConversationUsecase{
+		chatModel:           chatModel,
+		conversationService: conversationService,
+		fileQueryService:    fileQueryService,
+		sourceRepositories:  sourceRepositories,
+		remainingStepCount:  10, // デフォルトのステップ数
+	}
+
+	for _, option := range options {
+		option(u)
+	}
+
+	return u
+}
+
+// Execute は会話ユースケースを実行します。
+func (u *ConversationUsecase) Execute(ctx context.Context) error {
+	go u.conversationService.MarkEyes()
+	defer u.conversationService.RemoveEyes()
+
+	// 会話履歴を取得
+	chatHistory, err := u.conversationService.GetHistory()
+	if err != nil {
+		return fmt.Errorf("failed to get chat history: %w", err)
+	}
+
+	// SourceRepositoryManagerの初期化
+	sourceRepositoryManager := port.NewSourceRepositoryManager(u.sourceRepositories)
+
+	// ハンドラーの初期化
+	attemptCompleteHandler := tooluse.NewAttemptCompleteHandler(u.conversationService)
+	findFileHandler := tooluse.NewFindFileHandler(ctx, u.fileQueryService)
+	queryRAGHandler := tooluse.NewQueryRAGHandler(ctx, u.ragCorpus)
+	findSourceHandler := tooluse.NewFindSourceHandler(ctx, sourceRepositoryManager)
+
+	// ツールケースの設定
+	cases := domaintooluse.Cases{
+		AttemptComplete: attemptCompleteHandler.Handle,
+		FindFile:        findFileHandler.Handle,
+		QueryRAG:        queryRAGHandler.Handle,
+		FindSource:      findSourceHandler.Handle,
+	}
+
+	// エージェントの初期化
+	agent := domain.NewAgent(
+		u.chatModel,
+		buildSystemInstructionForConversation(u.ragCorpus != nil),
+		cases,
+	)
+
+	// タスク文字列の構築
+	var task strings.Builder
+	task.WriteString("<task>\n")
+	task.WriteString("A user has sent you a new message on chat. Respond based on the history of the most recent conversation.\n")
+	if u.ragCorpus != nil {
+		task.WriteString("If it is a question that requires domain-specific knowledge to answer, use tools to retrieve relevant knowledge before responding.\n")
+	} else {
+		task.WriteString("It may be a question that requires domain-specific knowledge to answer, but unfortunately you do not have access to that knowledge. Please respond in good faith based on your general knowledge.\n")
+	}
+	task.WriteString("</task>\n")
+	task.WriteString(chatHistory.ToXML())
+
+	// タスク実行ループの開始
+	err = agent.InitiateTaskLoop(ctx, task.String(), u.remainingStepCount)
+	if err != nil {
+		if replyErr := u.conversationService.Reply("Something went wrong. Please try again later.", true); replyErr != nil {
+			return fmt.Errorf("failed to reply error message: %w", replyErr)
+		}
+		return fmt.Errorf("failed to initiate task loop: %w", err)
+	}
+
+	return nil
+}
+
+// buildSystemInstructionForConversation は会話用のシステムプロンプトを構築します。
+func buildSystemInstructionForConversation(ragEnabled bool) *domain.SystemInstruction {
+	environments := []domain.EnvironmentContext{}
+
+	if ragEnabled {
+		environments = append(environments, domain.NewEnvironmentContext("Conversation Workflow", `1. UNDERSTAND the conversation context
+		a. Analyze the conversation history to grasp the user's intent
+		b. Accurately comprehend the current question or request
+	  
+	  2. RESEARCH and UTILIZE knowledge
+		a. Use query_rag to search for relevant knowledge related to the question
+		b. Use find_file to examine document details when necessary
+		c. Use find_source to check the origin of related information and deepen understanding
+	  
+	  3. GENERATE appropriate response
+		a. Organize collected information to create concise and accurate answers
+		b. Directly address the user's question
+		c. Add explanations for technical terms when necessary
+		d. Use attempt_complete to respond and end the conversation`))
+	}
+
+	toolUses := []domaintooluse.Usage{
+		domaintooluse.AttemptCompleteUsage,
+	}
+
+	if ragEnabled {
+		toolUses = append(toolUses, domaintooluse.QueryRAGUsage)
+		toolUses = append(toolUses, domaintooluse.FindFileUsage)
+		toolUses = append(toolUses, domaintooluse.FindSourceUsage)
+	}
+
+	return domain.NewSystemInstruction(
+		environments,
+		toolUses,
+	)
+}

--- a/internal/application/conversation_test.go
+++ b/internal/application/conversation_test.go
@@ -1,0 +1,216 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"docgent/internal/application/port"
+	"docgent/internal/domain/data"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSourceRepositoryがport.SourceRepositoryインターフェースを実装するよう修正
+type MockSourceRepository struct {
+	mock.Mock
+}
+
+func (m *MockSourceRepository) Match(uri *data.URI) bool {
+	args := m.Called(uri)
+	return args.Bool(0)
+}
+
+func (m *MockSourceRepository) Find(ctx context.Context, uri *data.URI) (*data.Source, error) {
+	args := m.Called(ctx, uri)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*data.Source), args.Error(1)
+}
+
+func TestConversationUsecase_Execute(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*MockChatModel, *MockChatSession, *MockConversationService, *MockFileQueryService, *MockSourceRepository, *MockRAGCorpus)
+		expectedError error
+		disableRAG    bool
+	}{
+		{
+			name: "正常系：基本的な会話が成功する",
+			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, sourceRepository *MockSourceRepository, ragCorpus *MockRAGCorpus) {
+				conversationService.On("MarkEyes").Return(nil).Once()
+				conversationService.On("RemoveEyes").Return(nil).Once()
+
+				// 会話履歴を返す
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "こんにちは"},
+						{Author: "docgent", Content: "こんにちは！何かお手伝いできることはありますか？", IsYou: true},
+						{Author: "user", Content: "APIの使い方を教えてください", YouMentioned: true},
+					},
+				}, nil).Once()
+
+				// チャットモデルの設定
+				chatModel.On("StartChat", mock.Anything).Return(chatSession).Once()
+
+				// エージェントのタスクループの実行
+				// 1回目のメッセージ：RAGクエリを実行
+				chatSession.On("SendMessage", mock.Anything, mock.Anything).Return(`<query_rag><query>APIの使い方</query></query_rag>`, nil).Once()
+
+				// RAGクエリの結果
+				ragCorpus.On("Query", mock.Anything, "APIの使い方", int32(10), float64(0.7)).Return([]port.RAGDocument{
+					{
+						Content: "APIの使い方ドキュメント",
+						Source:  "docs/api.md",
+						Score:   0.85,
+					},
+				}, nil).Once()
+
+				// 2回目のメッセージ：ファイル内容を確認
+				chatSession.On("SendMessage", mock.Anything, mock.Anything).Return(`<find_file><path>docs/api.md</path></find_file>`, nil).Once()
+
+				// ファイル内容を返す
+				fileQueryService.On("FindFile", mock.Anything, "docs/api.md").Return(data.File{
+					Path:    "docs/api.md",
+					Content: "# API使用方法\n\nこのAPIは以下のエンドポイントを提供しています...",
+				}, nil).Once()
+
+				// 3回目のメッセージ：解答を生成
+				chatSession.On("SendMessage", mock.Anything, mock.Anything).Return(`<attempt_complete>
+APIの使い方について説明します。ドキュメントによると、このAPIは複数のエンドポイントを提供しており...
+</attempt_complete>`, nil).Once()
+
+				// 回答を返す
+				conversationService.On("Reply", mock.Anything, true).Return(nil).Once()
+			},
+			expectedError: nil,
+		},
+		{
+			name: "正常系：RAGなしで会話が成功する",
+			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, sourceRepository *MockSourceRepository, ragCorpus *MockRAGCorpus) {
+				conversationService.On("MarkEyes").Return(nil).Once()
+				conversationService.On("RemoveEyes").Return(nil).Once()
+
+				// 会話履歴を返す
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "こんにちは"},
+						{Author: "docgent", Content: "こんにちは！何かお手伝いできることはありますか？", IsYou: true},
+						{Author: "user", Content: "調子はどう？", YouMentioned: true},
+					},
+				}, nil).Once()
+
+				// チャットモデルの設定
+				chatModel.On("StartChat", mock.Anything).Return(chatSession).Once()
+
+				// メッセージの送信
+				chatSession.On("SendMessage", mock.Anything, mock.Anything).Return(`<attempt_complete>
+こんにちは！私は元気です。あなたはどうですか？
+</attempt_complete>`, nil).Once()
+
+				// 回答を返す
+				conversationService.On("Reply", mock.Anything, true).Return(nil).Once()
+			},
+			expectedError: nil,
+			disableRAG:    true,
+		},
+		{
+			name: "エラー系：会話履歴の取得に失敗する",
+			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, sourceRepository *MockSourceRepository, ragCorpus *MockRAGCorpus) {
+				conversationService.On("MarkEyes").Return(nil).Once()
+				conversationService.On("RemoveEyes").Return(nil).Once()
+
+				// 会話履歴の取得に失敗
+				conversationService.On("GetHistory").Return(port.ConversationHistory{}, errors.New("failed to retrieve conversation history")).Once()
+			},
+			expectedError: errors.New("failed to get chat history"),
+		},
+		{
+			name: "エラー系：タスク実行ループでエラーが発生する",
+			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, sourceRepository *MockSourceRepository, ragCorpus *MockRAGCorpus) {
+				conversationService.On("MarkEyes").Return(nil).Once()
+				conversationService.On("RemoveEyes").Return(nil).Once()
+
+				// 会話履歴を返す
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "こんにちは", YouMentioned: true},
+					},
+				}, nil).Once()
+
+				// チャットモデルの設定
+				chatModel.On("StartChat", mock.Anything).Return(chatSession).Once()
+
+				// メッセージ送信でエラー
+				chatSession.On("SendMessage", mock.Anything, mock.Anything).Return("", errors.New("failed to generate response")).Once()
+
+				// エラー通知
+				conversationService.On("Reply", "Something went wrong. Please try again later.", true).Return(nil).Once()
+			},
+			expectedError: errors.New("failed to initiate task loop: failed to generate response"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chatModel := new(MockChatModel)
+			chatSession := new(MockChatSession)
+			conversationService := new(MockConversationService)
+			conversationService.markEyesWaitGroup = &sync.WaitGroup{}
+			conversationService.markEyesWaitGroup.Add(1)
+			fileQueryService := new(MockFileQueryService)
+			sourceRepository := new(MockSourceRepository)
+			ragCorpus := new(MockRAGCorpus)
+
+			// モックの設定
+			tt.setupMocks(chatModel, chatSession, conversationService, fileQueryService, sourceRepository, ragCorpus)
+
+			// ConversationUsecaseの作成
+			var usecase *ConversationUsecase
+			if tt.disableRAG {
+				usecase = NewConversationUsecase(
+					chatModel,
+					conversationService,
+					fileQueryService,
+					[]port.SourceRepository{sourceRepository},
+				)
+			} else {
+				usecase = NewConversationUsecase(
+					chatModel,
+					conversationService,
+					fileQueryService,
+					[]port.SourceRepository{sourceRepository},
+					WithConversationRAGCorpus(ragCorpus),
+				)
+			}
+
+			// テスト実行
+			err := usecase.Execute(context.Background())
+
+			// 非同期処理の完了を待つ
+			conversationService.markEyesWaitGroup.Wait()
+
+			// 結果検証
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// モックの検証
+			chatModel.AssertExpectations(t)
+			chatSession.AssertExpectations(t)
+			conversationService.AssertExpectations(t)
+			fileQueryService.AssertExpectations(t)
+			sourceRepository.AssertExpectations(t)
+			ragCorpus.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/application/port/conversation.go
+++ b/internal/application/port/conversation.go
@@ -1,16 +1,62 @@
 package port
 
-import "docgent/internal/domain/data"
+import (
+	"docgent/internal/domain/data"
+	"encoding/xml"
+)
 
 type ConversationService interface {
 	Reply(input string, withMention bool) error
-	GetHistory() ([]ConversationMessage, error)
+	GetHistory() (ConversationHistory, error)
 	URI() *data.URI
 	MarkEyes() error
 	RemoveEyes() error
 }
 
+type ConversationHistory struct {
+	URI      *data.URI
+	Messages []ConversationMessage
+}
+
 type ConversationMessage struct {
-	Author  string
-	Content string
+	Author       string
+	Content      string
+	YouMentioned bool
+	IsYou        bool
+}
+
+func (c ConversationHistory) ToXML() string {
+	messages := make([]conversationMessage, len(c.Messages))
+	for i, message := range c.Messages {
+		messages[i] = conversationMessage{
+			Author:       message.Author,
+			Content:      message.Content,
+			YouMentioned: message.YouMentioned,
+			IsYou:        message.IsYou,
+		}
+	}
+	history := conversationHistory{
+		URI:      c.URI.String(),
+		Messages: messages,
+	}
+
+	xmlData, err := xml.MarshalIndent(history, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(xmlData)
+}
+
+type conversationHistory struct {
+	XMLName  xml.Name              `xml:"conversation"`
+	URI      string                `xml:"uri,attr"`
+	Messages []conversationMessage `xml:"message"`
+}
+
+type conversationMessage struct {
+	XMLName      xml.Name `xml:"message"`
+	Author       string   `xml:"author,attr"`
+	IsYou        bool     `xml:"is_you,attr,omitempty"`
+	YouMentioned bool     `xml:"you_mentioned,attr,omitempty"`
+	Content      string   `xml:",chardata"`
 }

--- a/internal/application/port/conversation_test.go
+++ b/internal/application/port/conversation_test.go
@@ -1,0 +1,74 @@
+package port
+
+import (
+	"docgent/internal/domain/data"
+	"strings"
+	"testing"
+)
+
+func TestConversationHistory_ToXML(t *testing.T) {
+	tests := []struct {
+		name     string
+		history  ConversationHistory
+		expected []string // XMLの中に含まれるべき文字列
+	}{
+		{
+			name: "通常の会話履歴",
+			history: ConversationHistory{
+				URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+				Messages: []ConversationMessage{
+					{
+						Author:       "user1",
+						Content:      "こんにちは",
+						YouMentioned: false,
+						IsYou:        false,
+					},
+					{
+						Author:       "bot",
+						Content:      "はい、こんにちは",
+						YouMentioned: false,
+						IsYou:        true,
+					},
+				},
+			},
+			expected: []string{
+				`<conversation uri="https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000">`,
+				`<message author="user1">こんにちは</message>`,
+				`<message author="bot" is_you="true">はい、こんにちは</message>`,
+				`</conversation>`,
+			},
+		},
+		{
+			name: "メンション付きメッセージを含む会話",
+			history: ConversationHistory{
+				URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+				Messages: []ConversationMessage{
+					{
+						Author:       "user2",
+						Content:      "@bot 質問があります",
+						YouMentioned: true,
+						IsYou:        false,
+					},
+				},
+			},
+			expected: []string{
+				`<conversation uri="https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000">`,
+				`<message author="user2" you_mentioned="true">@bot 質問があります</message>`,
+				`</conversation>`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.history.ToXML()
+
+			// 期待される文字列が全て含まれているか確認
+			for _, exp := range tt.expected {
+				if !strings.Contains(result, exp) {
+					t.Errorf("ToXML() の結果に %q が含まれていません\n結果: %s", exp, result)
+				}
+			}
+		})
+	}
+}

--- a/internal/application/proposal_generate.go
+++ b/internal/application/proposal_generate.go
@@ -61,8 +61,6 @@ func (w *ProposalGenerateUsecase) Execute(ctx context.Context) (domain.ProposalH
 	go w.conversationService.MarkEyes()
 	defer w.conversationService.RemoveEyes()
 
-	conversationURI := w.conversationService.URI()
-
 	chatHistory, err := w.conversationService.GetHistory()
 	if err != nil {
 		return domain.ProposalHandle{}, fmt.Errorf("failed to get chat history: %w", err)
@@ -113,11 +111,7 @@ func (w *ProposalGenerateUsecase) Execute(ctx context.Context) (domain.ProposalH
 	task.WriteString("<task>\n")
 	task.WriteString("Create a new proposal by following the proposal generation workflow.\n")
 	task.WriteString("</task>\n")
-	task.WriteString(fmt.Sprintf("<conversation uri=%q>\n", conversationURI.String()))
-	for _, msg := range chatHistory {
-		task.WriteString(fmt.Sprintf("<message author=%q>\n%s\n</message>\n", msg.Author, msg.Content))
-	}
-	task.WriteString("</conversation>\n")
+	task.WriteString(chatHistory.ToXML())
 
 	err = agent.InitiateTaskLoop(ctx, task.String(), w.remainingStepCount)
 	if err != nil {

--- a/internal/application/proposal_generate_test.go
+++ b/internal/application/proposal_generate_test.go
@@ -54,9 +54,9 @@ func (m *MockConversationService) URI() *data.URI {
 	return args.Get(0).(*data.URI)
 }
 
-func (m *MockConversationService) GetHistory() ([]port.ConversationMessage, error) {
+func (m *MockConversationService) GetHistory() (port.ConversationHistory, error) {
 	args := m.Called()
-	return args.Get(0).([]port.ConversationMessage), args.Error(1)
+	return args.Get(0).(port.ConversationHistory), args.Error(1)
 }
 
 func (m *MockConversationService) MarkEyes() error {
@@ -178,12 +178,13 @@ func TestProposalGenerateUsecase_Execute(t *testing.T) {
 			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, fileRepository *MockFileRepository, proposalRepository *MockProposalRepository, ragCorpus *MockRAGCorpus) {
 				conversationService.On("MarkEyes").Return(nil).Once()
 				conversationService.On("RemoveEyes").Return(nil).Once()
-				conversationService.On("URI").Return(data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000")).Once()
-
-				conversationService.On("GetHistory").Return([]port.ConversationMessage{
-					{Author: "user", Content: "APIの仕様書を作成してください"},
-					{Author: "assistant", Content: "承知しました。どのような内容を含めるべきでしょうか？"},
-					{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "APIの仕様書を作成してください"},
+						{Author: "docgent", Content: "承知しました。どのような内容を含めるべきでしょうか？", IsYou: true},
+						{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+					},
 				}, nil)
 
 				fileQueryService.On("GetTree", mock.Anything, mock.AnythingOfType("[]port.GetTreeOption")).Return([]port.TreeMetadata{
@@ -228,11 +229,13 @@ func TestProposalGenerateUsecase_Execute(t *testing.T) {
 			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, fileRepository *MockFileRepository, proposalRepository *MockProposalRepository, ragCorpus *MockRAGCorpus) {
 				conversationService.On("MarkEyes").Return(nil).Once()
 				conversationService.On("RemoveEyes").Return(nil).Once()
-				conversationService.On("URI").Return(data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000")).Once()
-				conversationService.On("GetHistory").Return([]port.ConversationMessage{
-					{Author: "user", Content: "APIの仕様書を作成してください"},
-					{Author: "assistant", Content: "承知しました。どのような内容を含めるべきでしょうか？"},
-					{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "APIの仕様書を作成してください"},
+						{Author: "docgent", Content: "承知しました。どのような内容を含めるべきでしょうか？", IsYou: true},
+						{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+					},
 				}, nil)
 				fileQueryService.On("GetTree", mock.Anything, mock.AnythingOfType("[]port.GetTreeOption")).Return([]port.TreeMetadata{
 					{Path: "docs/api.md", Type: port.NodeTypeFile, Size: 100},
@@ -249,12 +252,13 @@ func TestProposalGenerateUsecase_Execute(t *testing.T) {
 			setupMocks: func(chatModel *MockChatModel, chatSession *MockChatSession, conversationService *MockConversationService, fileQueryService *MockFileQueryService, fileRepository *MockFileRepository, proposalRepository *MockProposalRepository, ragCorpus *MockRAGCorpus) {
 				conversationService.On("MarkEyes").Return(nil).Once()
 				conversationService.On("RemoveEyes").Return(nil).Once()
-				conversationService.On("URI").Return(data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000")).Once()
-
-				conversationService.On("GetHistory").Return([]port.ConversationMessage{
-					{Author: "user", Content: "APIの仕様書を作成してください"},
-					{Author: "assistant", Content: "承知しました。どのような内容を含めるべきでしょうか？"},
-					{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+				conversationService.On("GetHistory").Return(port.ConversationHistory{
+					URI: data.NewURIUnsafe("https://app.slack.com/client/T00000000/C00000000/thread/T00000000-00000000"),
+					Messages: []port.ConversationMessage{
+						{Author: "user", Content: "APIの仕様書を作成してください"},
+						{Author: "docgent", Content: "承知しました。どのような内容を含めるべきでしょうか？", IsYou: true},
+						{Author: "user", Content: "エンドポイント、リクエスト、レスポンスの形式を含めてください"},
+					},
 				}, nil)
 				fileQueryService.On("GetTree", mock.Anything, mock.AnythingOfType("[]port.GetTreeOption")).Return([]port.TreeMetadata{
 					{Path: "docs/api.md", Type: port.NodeTypeFile, Size: 100},

--- a/internal/infrastructure/github/review_comment_conversation_service.go
+++ b/internal/infrastructure/github/review_comment_conversation_service.go
@@ -30,7 +30,7 @@ func NewReviewCommentConversationService(client *github.Client, owner, repo stri
 	}
 }
 
-func (s *ReviewCommentConversationService) GetHistory() ([]port.ConversationMessage, error) {
+func (s *ReviewCommentConversationService) GetHistory() (port.ConversationHistory, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
relates #3

Slackでメンションされたとき、従来はQuestionAnswerUsecaseを呼び出して、決まったワークフローで応答を返すようにしていましたが、ConversationUsecaseを新設して以下のツールを使って柔軟に応答をかえせるようにしました。

- query_rag
- find_file
- find_source
- attempt_complete